### PR TITLE
Parallelize stats

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,7 @@
 # as defined here: https://dumps.wikimedia.org/
 #
 # NOTE: in practice the actual limitation appears to be set to 3
-WIKIDATA_PARALLEL_DOWNLOADS = 2
+WIKIMEDIA_PARALLEL_DOWNLOADS = 2
 
 #  __        ___ _    _ ____        _
 #  \ \      / (_) | _(_)  _ \  __ _| |_ __ _

--- a/src/config.py
+++ b/src/config.py
@@ -39,7 +39,7 @@ STATS_DUMP_FILES = [
     'pageviews-{year:04d}{month:02d}{day:02d}-{hour:02d}0000.gz'.format(
         year=2019, month=month, day=day, hour=hour
     )
-    for month in range(3, 4)
+    for month in range(6, 10)
     for day in range(1, 32)
     for hour in range(24)
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,9 @@
+# Wikimedia dump server only allows for a limited amount of per-ip connections
+# as defined here: https://dumps.wikimedia.org/
+#
+# NOTE: in practice the actual limitation appears to be set to 3
+WIKIDATA_PARALLEL_DOWNLOADS = 2
+
 #  __        ___ _    _ ____        _
 #  \ \      / (_) | _(_)  _ \  __ _| |_ __ _
 #   \ \ /\ / /| | |/ / | | | |/ _` | __/ _` |
@@ -33,7 +39,7 @@ STATS_DUMP_FILES = [
     'pageviews-{year:04d}{month:02d}{day:02d}-{hour:02d}0000.gz'.format(
         year=2019, month=month, day=day, hour=hour
     )
-    for month in range(6, 10)
+    for month in range(3, 4)
     for day in range(1, 32)
     for hour in range(24)
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -30,8 +30,14 @@ WIKIDATA_LABEL_LANGUAGES = WIKIDATA_FILTER_WIKI_LANGUAGE
 # Directory where to download dumps
 STATS_DUMP_DIR = 'dumps/stats'
 
-# Base URL to download dumps
-STATS_ENDPOINT = 'https://dumps.wikimedia.org/other/pageviews'
+# Base URL to download dumps.
+# 
+# The official wikimedia endpoint can be found there:
+#   https://dumps.wikimedia.org/other/pageviews
+# However, you may prefer using unofficial mirrors with higher access
+# limitations, a list of mirrors is available here:
+#   https://dumps.wikimedia.org/mirrors.html
+STATS_ENDPOINT = 'https://ftp.acc.umu.se/mirror/wikimedia.org/other/pageviews/'
 
 # Files to download and load
 STATS_DUMP_FILES = [

--- a/src/download_stats.py
+++ b/src/download_stats.py
@@ -25,7 +25,7 @@ def apply_download(dump_file):
 
 
 def download_stats():
-    pool = multiprocessing.Pool(config.WIKIDATA_PARALLEL_DOWNLOADS)
+    pool = multiprocessing.Pool(config.WIKIMEDIA_PARALLEL_DOWNLOADS)
 
     for i, msg in enumerate(
         pool.imap(apply_download, config.STATS_DUMP_FILES)

--- a/src/download_stats.py
+++ b/src/download_stats.py
@@ -1,30 +1,36 @@
 #!/usr/bin/env python3
+import multiprocessing
 import os
-import sys
 import urllib.request
 
 import config
 
 
+def apply_download(dump_file):
+    path = os.path.join(config.STATS_DUMP_DIR, dump_file)
+    url = os.path.join(config.STATS_ENDPOINT, dump_file)
+
+    if os.path.exists(path):
+        return 'skipped existing {}'.format(path)
+
+    # Download the file
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    try:
+        urllib.request.urlretrieve(url, path)
+    except Exception as e:
+        return 'skipped {}: {}'.format(path, e)
+
+    return '{} done'.format(path)
+
+
 def download_stats():
-    for i, dump_file in enumerate(config.STATS_DUMP_FILES):
-        path = os.path.join(config.STATS_DUMP_DIR, dump_file)
+    pool = multiprocessing.Pool(config.WIKIDATA_PARALLEL_DOWNLOADS)
 
-        if os.path.exists(path):
-            print(
-                '({}/{}) Skipped existing {}'.format(
-                    i + 1, len(config.STATS_DUMP_FILES), path
-                )
-            )
-            continue
+    for i, msg in enumerate(
+        pool.imap_unordered(apply_download, config.STATS_DUMP_FILES)
+    ):
+        print('({}/{})'.format(i + 1, len(config.STATS_DUMP_FILES)), msg)
 
-        url = os.path.join(config.STATS_ENDPOINT, dump_file)
-        print('({}/{}) {}'.format(i + 1, len(config.STATS_DUMP_FILES), path))
-
-        # Download the file
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-
-        try:
-            urllib.request.urlretrieve(url, path)
-        except Exception as e:
-            print('Skipped:', e, file=sys.stdout)
+    pool.close()
+    pool.join()

--- a/src/download_stats.py
+++ b/src/download_stats.py
@@ -28,7 +28,7 @@ def download_stats():
     pool = multiprocessing.Pool(config.WIKIDATA_PARALLEL_DOWNLOADS)
 
     for i, msg in enumerate(
-        pool.imap_unordered(apply_download, config.STATS_DUMP_FILES)
+        pool.imap(apply_download, config.STATS_DUMP_FILES)
     ):
         print('({}/{})'.format(i + 1, len(config.STATS_DUMP_FILES)), msg)
 

--- a/src/load_stats.py
+++ b/src/load_stats.py
@@ -4,6 +4,7 @@ import gzip
 import multiprocessing
 import os
 import sys
+from collections import defaultdict
 
 import config
 
@@ -13,7 +14,7 @@ def load_file(input_filename: str) -> dict:
     Load stats for an input file into a dictionary: dict[lang][page] contains
     the count of views of `page` for the language `lang`.
     """
-    stats = {site: dict() for site in config.STATS_SITES}
+    stats = {site: defaultdict(int) for site in config.STATS_SITES}
 
     try:
         input_file = gzip.open(input_filename, 'rt')
@@ -38,10 +39,7 @@ def load_file(input_filename: str) -> dict:
         if site not in config.STATS_SITES:
             continue
 
-        if page not in stats[site]:
-            stats[site][page] = int(views)
-        else:
-            stats[site][page] += int(views)
+        stats[site][page] += int(views)
 
     input_file.close()
     return stats
@@ -62,7 +60,7 @@ def load_stats(output_file):
     #  |____/ \__,_|_| |_| |_|    \_/  |_|\___| \_/\_/ |___/
     #
 
-    stats = {site: dict() for site in config.STATS_SITES}
+    stats = {site: defaultdict(int) for site in config.STATS_SITES}
     pool = multiprocessing.Pool()
 
     for i_file, file_stats in enumerate(pool.imap(load_file, files)):
@@ -77,7 +75,6 @@ def load_stats(output_file):
 
         for lang, pages in file_stats.items():
             for page, views in pages.items():
-                stats[lang].setdefault(page, 0)
                 stats[lang][page] += views
 
     pool.close()

--- a/src/load_stats.py
+++ b/src/load_stats.py
@@ -61,7 +61,14 @@ def load_stats(output_file):
     #
 
     stats = {site: defaultdict(int) for site in config.STATS_SITES}
-    pool = multiprocessing.Pool()
+
+    # Keep one free CPU core to help the main process keeping up with the
+    # collection step.
+    #
+    # NOTE: If this becomes a real issue a fine way to fix this would be to
+    #       distribute the collection step into the loading tasks by using a
+    #       global lock on the computed structure.
+    pool = multiprocessing.Pool(max(1, multiprocessing.cpu_count() - 1))
 
     for i_file, file_stats in enumerate(pool.imap(load_file, files)):
         print(

--- a/src/load_stats.py
+++ b/src/load_stats.py
@@ -18,7 +18,7 @@ def load_file(input_filename: str) -> dict:
     try:
         input_file = gzip.open(input_filename, 'rt')
     except FileNotFoundError as e:
-        print('Skipped unexisting file', input_file, file=sys.stderr)
+        print('Skipped unexisting file', input_filename, file=sys.stderr)
         return dict()
 
     for i_line, line in enumerate(input_file):


### PR DESCRIPTION
Parallelize both the download and the extraction of statistics from Wikimedia dumps.

Note that the download won't be much faster as Wikimedia only allow for two simultaneous connections (each appearing to be capped to 2MB/s): https://dumps.wikimedia.org/.

EDIT: [...] which isn't really an issue if we change the endpoint to one of these mirrors: https://dumps.wikimedia.org/mirrors.html, thanks to amatissart's remark